### PR TITLE
MpegStreamReader: fix NPE in SeekTo

### DIFF
--- a/NLayer/Decoder/MpegStreamReader.cs
+++ b/NLayer/Decoder/MpegStreamReader.cs
@@ -631,7 +631,7 @@ namespace NLayer.Decoder
             // first try to "seek" by calculating the frame number
             var cnt = (int)(sampleNumber / _first.SampleCount);
             var frame = _first;
-            if (_current.Number <= cnt && _current.SampleOffset <= sampleNumber)
+            if (_current != null && _current.Number <= cnt && _current.SampleOffset <= sampleNumber)
             {
                 // if this fires, we can short-circuit things a bit...
                 frame = _current;


### PR DESCRIPTION
After last frame was read by MpegStreamReader.NextFrame, any SeekTo(frameNumber) failed because of a NullPointerException for accessing _current.
Fixed by adding a null check so that _current will be set correctly to the desired frame.