### PR TITLE
fixed ID3v2.2 frame identification

### DIFF
--- a/NLayer/Decoder/ID3Frame.cs
+++ b/NLayer/Decoder/ID3Frame.cs
@@ -48,6 +48,9 @@ namespace NLayer.Decoder
                         byte flagsMask;
                         switch (buf[0])
                         {
+                            case 2:
+                                flagsMask = 0x3F;
+                                break;
                             case 3:
                                 flagsMask = 0x1F;
                                 break;


### PR DESCRIPTION
Flag bits meaning according to the spec:
bit 7: unsynchronisation
bit 6: compression, "Since no compression scheme has been decided yet, the ID3 decoder (for now) should just ignore the entire tag if the compression bit is set."
other flag bits are unused