### PR TITLE
FIxed Index out of range exception that can occure for some MP3 songs…

### DIFF
--- a/NLayer/Decoder/LayerIIIDecoder.cs
+++ b/NLayer/Decoder/LayerIIIDecoder.cs
@@ -1385,21 +1385,14 @@ namespace NLayer.Decoder
             h = _count1TableSelect[gr][ch] + 32;
 
             float v, w;
-            while (part3end > _bitRes.BitsRead && idx < SBLIMIT * SSLIMIT)
+            // - 3 to ensure that we never get an out of range exception
+            while (part3end > _bitRes.BitsRead && idx < SBLIMIT * SSLIMIT - 3)
             {
                 Huffman.Decode(_bitRes, h, out x, out y, out v, out w);
-                _samples[ch][idx] = Dequantize(idx, v, gr, ch);
-                if (idx < (SBLIMIT * SSLIMIT) - 1)
-                    ++idx;
-                _samples[ch][idx] = Dequantize(idx, w, gr, ch);
-                if (idx < (SBLIMIT * SSLIMIT) - 1)
-                    ++idx;
-                _samples[ch][idx] = Dequantize(idx, x, gr, ch);
-                if (idx < (SBLIMIT * SSLIMIT) - 1)
-                    ++idx;
-                _samples[ch][idx] = Dequantize(idx, y, gr, ch);
-                if (idx < (SBLIMIT * SSLIMIT) - 1)
-                    ++idx;
+                _samples[ch][idx] = Dequantize(idx, v, gr, ch); ++idx;
+                _samples[ch][idx] = Dequantize(idx, w, gr, ch); ++idx;
+                _samples[ch][idx] = Dequantize(idx, x, gr, ch); ++idx;
+                _samples[ch][idx] = Dequantize(idx, y, gr, ch); ++idx;
             }
 
             // adjust the bit stream if we're off somehow

--- a/NLayer/Decoder/LayerIIIDecoder.cs
+++ b/NLayer/Decoder/LayerIIIDecoder.cs
@@ -1388,10 +1388,18 @@ namespace NLayer.Decoder
             while (part3end > _bitRes.BitsRead && idx < SBLIMIT * SSLIMIT)
             {
                 Huffman.Decode(_bitRes, h, out x, out y, out v, out w);
-                _samples[ch][idx] = Dequantize(idx, v, gr, ch); ++idx;
-                _samples[ch][idx] = Dequantize(idx, w, gr, ch); ++idx;
-                _samples[ch][idx] = Dequantize(idx, x, gr, ch); ++idx;
-                _samples[ch][idx] = Dequantize(idx, y, gr, ch); ++idx;
+                _samples[ch][idx] = Dequantize(idx, v, gr, ch);
+                if (idx < (SBLIMIT * SSLIMIT) - 1)
+                    ++idx;
+                _samples[ch][idx] = Dequantize(idx, w, gr, ch);
+                if (idx < (SBLIMIT * SSLIMIT) - 1)
+                    ++idx;
+                _samples[ch][idx] = Dequantize(idx, x, gr, ch);
+                if (idx < (SBLIMIT * SSLIMIT) - 1)
+                    ++idx;
+                _samples[ch][idx] = Dequantize(idx, y, gr, ch);
+                if (idx < (SBLIMIT * SSLIMIT) - 1)
+                    ++idx;
             }
 
             // adjust the bit stream if we're off somehow


### PR DESCRIPTION
Because of the way it was written, idx could become bigger than SBLIMIT * SSLIMIT within the while, causing an index out of range exception inside the Dequantize method, throwing and stopping to play the song altogether. This fixed that issue allowing the otherwise valid MP3 song to continue playing.