### PR TITLE
#32 Add in netstandard 2.0

### DIFF
--- a/NLayer/NLayer.csproj
+++ b/NLayer/NLayer.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Mark Heath, Andrew Ward</Authors>
-    <Version>1.15.0</Version>
+    <Version>1.16.0</Version>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/naudio/NLayer</PackageProjectUrl>
     <Description>Fully Managed MPEG 1 &amp; 2 Decoder for Layers 1, 2, &amp; 3</Description>


### PR DESCRIPTION
Adds net standard 2.0 as TFM so that no dependencies are needed on newer frameworks

Closes #32