### PR TITLE
Remove outdated JavaLayer reference and dead CodePlex link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # NLayer
 
-NLayer is a fully managed MP3 to WAV decoder. The code was originally based 
-on [JavaLayer](http://www.javazoom.net/javalayer/javalayer.html) (v1.0.1), 
-which has been ported to C#.
+NLayer is a fully managed, MIT-licensed MP3 to WAV decoder implemented in C# based on the MPEG specifications.
 
 Was previously hosted at [nlayer.codeplex.com](http://nlayer.codeplex.com/). 
 Please see the history there for full details of contributors.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 NLayer is a fully managed, MIT-licensed MP3 to WAV decoder implemented in C# based on the MPEG specifications.
 
-Was previously hosted at [nlayer.codeplex.com](http://nlayer.codeplex.com/). 
-Please see the history there for full details of contributors.
-
 ## Usage
 
 To use NLayer for decoding MP3, first reference NLayer.


### PR DESCRIPTION
Fixes #42

The README described NLayer as a port of JavaLayer (LGPL), which was causing confusion about the project's license. As clarified in #42, the codebase was completely rewritten from scratch based on the MPEG specifications — no JavaLayer code remains — so the MIT license is correct.

This PR removes the misleading JavaLayer reference and also drops the now-dead CodePlex link.