### PR TITLE
Fix IndexOutOfRangeException in LayerIIIDecoder.ApplyIStereo

### DIFF
--- a/NLayer/Decoder/LayerIIIDecoder.cs
+++ b/NLayer/Decoder/LayerIIIDecoder.cs
@@ -1552,7 +1552,7 @@ namespace NLayer.Decoder
                         var i = _sfBandIndexL[sfb];
                         var width = _sfBandIndexL[sfb + 1] - _sfBandIndexL[sfb];
                         var isPos = _scalefac[1][3][sfb];
-                        if (isPos == 7)
+                        if (isPos >= 7)
                         {
                             if (midSide)
                             {
@@ -1577,7 +1577,7 @@ namespace NLayer.Decoder
                     {
                         // do final long processing
                         var isPos = _scalefac[1][3][20];
-                        if (isPos == 7)
+                        if (isPos >= 7)
                         {
                             if (midSide)
                             {
@@ -1663,7 +1663,7 @@ namespace NLayer.Decoder
                                 if (sfb > sSfb[window])
                                 {
                                     var isPos = _scalefac[1][window][sfb];
-                                    if (isPos == 7)
+                                    if (isPos >= 7)
                                     {
                                         if (midSide)
                                         {
@@ -1701,7 +1701,7 @@ namespace NLayer.Decoder
                         for (window = 0; window < 3; window++)
                         {
                             var isPos = _scalefac[1][window][11];
-                            if (isPos == 7)
+                            if (isPos >= 7)
                             {
                                 if (midSide)
                                 {


### PR DESCRIPTION
Fixes #40

## Problem

When decoding certain MPEG-1 MP3 files using intensity stereo, `ApplyIStereo` threw an `IndexOutOfRangeException`. The root cause: the guard that decides whether to apply intensity stereo used an equality check (`isPos == 7`) rather than a range check.

In MPEG-1, scalefactor values for intensity stereo bands are read with up to **4 bits** (depending on `scalefac_compress`), so `isPos` can be 0–15. Values 0–6 are valid intensity stereo positions indexing into `_isRatio` (a 7-element array). Value 7 is the spec-defined "illegal" marker meaning "no intensity stereo here". But values 8–15 can also appear in real files and must be treated the same way — the old `== 7` check let them fall through to `ApplyIStereo`, which then accessed `_isRatio[0][isPos]` and `_isRatio[1][isPos]` out of bounds.

## Fix

Changed `if (isPos == 7)` → `if (isPos >= 7)` at all four intensity stereo guard sites in `LayerIIIDecoder.Stereo()`:

- Long block processing loop
- Final long block
- Short block inner window loop  
- Final short block loop

This matches the behaviour of established reference decoders such as libmad, which uses the same `>= 7` check with the comment `/* illegal intensity position */`.

## Verification

The sample file attached to issue #40 ("Земляне - Зеленая трава.mp3", a normal 2-channel 44100 Hz MP3) now decodes completely — all 6052 chunks — without exception and with no NaN/Inf values in the output.