### PR TITLE
Fix gapless playback: parse LAME tag and iTunSMPB for encoder delay/padding

### DIFF
--- a/NLayer/Decoder/ID3Frame.cs
+++ b/NLayer/Decoder/ID3Frame.cs
@@ -171,10 +171,113 @@ namespace NLayer.Decoder
             //}
         }
 
+        int _encoderDelay = -1;
+        int _encoderPadding = -1;
+        bool _v2Parsed;
+
         void ParseV2()
         {
-            // v2 is much more complicated than v1...  don't worry about it for now
-            // look for any merged frames, as well
+            _v2Parsed = true;
+            _encoderDelay = 0;
+            _encoderPadding = 0;
+
+            // Read version byte to determine frame size encoding
+            var header = new byte[7];
+            if (Read(3, header) != 7) return;
+
+            int majorVersion = header[0];
+            if (majorVersion != 3 && majorVersion != 4) return;
+
+            // Tag content size (syncsafe integer, 7 bits per byte)
+            int tagSize = (header[3] << 21) | (header[4] << 14) | (header[5] << 7) | header[6];
+
+            // Walk ID3v2 frames looking for TXXX "iTunSMPB"
+            int pos = 10; // skip 10-byte tag header
+            var frameBuf = new byte[10];
+            while (pos < tagSize + 10)
+            {
+                if (Read(pos, frameBuf, 0, 10) < 10) break;
+
+                // Frame ID: 4 ASCII bytes; null means padding, stop
+                if (frameBuf[0] == 0) break;
+
+                // Frame size: plain 32-bit in v2.3, syncsafe in v2.4
+                int frameSize;
+                if (majorVersion == 4)
+                    frameSize = (frameBuf[4] << 21) | (frameBuf[5] << 14) | (frameBuf[6] << 7) | frameBuf[7];
+                else
+                    frameSize = (frameBuf[4] << 24) | (frameBuf[5] << 16) | (frameBuf[6] << 8) | frameBuf[7];
+
+                if (frameSize <= 0) break;
+
+                bool isTxxx = frameBuf[0] == 'T' && frameBuf[1] == 'X' && frameBuf[2] == 'X' && frameBuf[3] == 'X';
+                if (isTxxx && frameSize < 4096)
+                {
+                    var data = new byte[frameSize];
+                    if (Read(pos + 10, data, 0, frameSize) == frameSize)
+                        TryParseITunSMPB(data, frameSize);
+                }
+
+                if (_encoderDelay > 0 || _encoderPadding > 0) break; // found it, stop scanning
+
+                pos += 10 + frameSize;
+            }
+        }
+
+        void TryParseITunSMPB(byte[] data, int length)
+        {
+            if (length < 2) return;
+            int enc = data[0];
+
+            // Decode entire frame content (description + NUL + value) as a string
+            string fullText;
+            try
+            {
+                Encoding encoding = (enc == 1 || enc == 2) ? Encoding.Unicode : Encoding.UTF8;
+                fullText = encoding.GetString(data, 1, length - 1);
+            }
+            catch { return; }
+
+            // Strip leading BOM if present
+            if (fullText.Length > 0 && fullText[0] == '\uFEFF')
+                fullText = fullText.Substring(1);
+
+            // Split on the NUL separator between description and value
+            int nullIdx = fullText.IndexOf('\0');
+            if (nullIdx < 0) return;
+
+            string desc = fullText.Substring(0, nullIdx);
+            if (desc != "iTunSMPB") return;
+
+            // Value: " 00000000 DELAY PADDING SAMPLECOUNT ..."
+            // UTF-16 frames carry a BOM before both the description and the value; strip it here too.
+            string value = fullText.Substring(nullIdx + 1).Trim('\0');
+            if (value.Length > 0 && value[0] == '\uFEFF')
+                value = value.Substring(1);
+            var parts = value.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length < 3) return;
+
+            if (int.TryParse(parts[1], System.Globalization.NumberStyles.HexNumber, null, out int delay) &&
+                int.TryParse(parts[2], System.Globalization.NumberStyles.HexNumber, null, out int padding))
+            {
+                _encoderDelay = delay;
+                _encoderPadding = padding;
+            }
+        }
+
+        internal void ParseEagerIfNeeded()
+        {
+            if (_version == 2 && !_v2Parsed) ParseV2();
+        }
+
+        internal int EncoderDelay
+        {
+            get { return _encoderDelay < 0 ? 0 : _encoderDelay; }
+        }
+
+        internal int EncoderPadding
+        {
+            get { return _encoderPadding < 0 ? 0 : _encoderPadding; }
         }
 
         internal int Version

--- a/NLayer/Decoder/MpegFrame.cs
+++ b/NLayer/Decoder/MpegFrame.cs
@@ -319,27 +319,25 @@ namespace NLayer.Decoder
                 info.VBRQuality = buf[0] << 24 | buf[1] << 16 | buf[2] << 8 | buf[3];
             }
 
-            //// now look for a LAME header (note: if it isn't found, it doesn't fail the VBR parse)
-            //do
-            //{
-            //    if (Read(offset, buf, 0, 20) != 20) break;
-            //    offset += 20;
+            // now look for a LAME header (note: if it isn't found, it doesn't fail the VBR parse)
+            do
+            {
+                // LAME tag is 9 bytes identifier + 27 bytes of data = 36 bytes total
+                // We need at least 24 bytes to reach the delay/padding field
+                if (Read(offset, buf, 0, 24) != 24) break;
 
-            //    // LAME tag revision: only 0 and 1 are valid
-            //    if ((buf[9] & 0xF0) > 0x10) break;
+                // "LAME" identifier (first 4 bytes)
+                if (buf[0] != 'L' || buf[1] != 'A' || buf[2] != 'M' || buf[3] != 'E') break;
 
-            //    // VBR mode: 0-6, 8 & 9 are valid
-            //    var mode = buf[9] & 0xF;
-            //    if (mode == 7 || mode > 9) break;
+                // Info tag revision (high nibble of byte 9): only 0 and 1 are valid
+                if ((buf[9] & 0xF0) > 0x10) break;
 
-            //    // Lowpass filter value
-            //    var lowpass = buf[10] / 100.0;
-
-            //    // Replay Gain
-            //    var rgPeak = BitConverter.ToSingle(buf, 11);
-            //    var rgGainRadio = buf[15] << 8 | buf[16];
-            //    var rgGain = buf[17] << 8 | buf[18];
-            //} while (false);
+                // Encoder delay and end padding are packed into bytes 21-23:
+                //   encoder_delay  = high 12 bits
+                //   end_padding    = low  12 bits
+                info.EncoderDelay   = (buf[21] << 4) | (buf[22] >> 4);
+                info.EncoderPadding = ((buf[22] & 0x0F) << 8) | buf[23];
+            } while (false);
 
             return info;
         }

--- a/NLayer/Decoder/MpegStreamReader.cs
+++ b/NLayer/Decoder/MpegStreamReader.cs
@@ -26,6 +26,11 @@ namespace NLayer.Decoder
 
             // find the first Mpeg frame
             var frame = FindNextFrame();
+
+            // Parse the ID3 tag now while the ReadBuffer is still near the start of the file.
+            // iTunSMPB gapless data must be read eagerly; backward seeks via ReadBuffer are unreliable.
+            _id3Frame?.ParseEagerIfNeeded();
+
             while (frame != null && !(frame is MpegFrame))
             {
                 frame = FindNextFrame();
@@ -602,12 +607,22 @@ namespace NLayer.Decoder
 
         internal int EncoderDelay
         {
-            get { return _vbrInfo != null ? _vbrInfo.EncoderDelay : 0; }
+            get
+            {
+                if (_vbrInfo != null && _vbrInfo.EncoderDelay > 0) return _vbrInfo.EncoderDelay;
+                if (_id3Frame != null) return _id3Frame.EncoderDelay;
+                return 0;
+            }
         }
 
         internal int EncoderPadding
         {
-            get { return _vbrInfo != null ? _vbrInfo.EncoderPadding : 0; }
+            get
+            {
+                if (_vbrInfo != null && _vbrInfo.EncoderPadding > 0) return _vbrInfo.EncoderPadding;
+                if (_id3Frame != null) return _id3Frame.EncoderPadding;
+                return 0;
+            }
         }
 
         internal int SampleRate

--- a/NLayer/Decoder/MpegStreamReader.cs
+++ b/NLayer/Decoder/MpegStreamReader.cs
@@ -600,6 +600,16 @@ namespace NLayer.Decoder
             }
         }
 
+        internal int EncoderDelay
+        {
+            get { return _vbrInfo != null ? _vbrInfo.EncoderDelay : 0; }
+        }
+
+        internal int EncoderPadding
+        {
+            get { return _vbrInfo != null ? _vbrInfo.EncoderPadding : 0; }
+        }
+
         internal int SampleRate
         {
             get

--- a/NLayer/Decoder/VBRInfo.cs
+++ b/NLayer/Decoder/VBRInfo.cs
@@ -11,6 +11,8 @@
         internal int VBRBytes { get; set; }
         internal int VBRQuality { get; set; }
         internal int VBRDelay { get; set; }
+        internal int EncoderDelay { get; set; }
+        internal int EncoderPadding { get; set; }
 
         internal long VBRStreamSampleCount
         {

--- a/NLayer/MpegFile.cs
+++ b/NLayer/MpegFile.cs
@@ -12,6 +12,8 @@ namespace NLayer
 
         object _seekLock = new object();
         long _position;
+        int _encoderDelay, _encoderPadding;
+        bool _decoderDelaySkipped;
 
         /// <summary>
         /// Construct Mpeg file representation from filename.
@@ -39,6 +41,9 @@ namespace NLayer
             _reader = new Decoder.MpegStreamReader(_stream);
 
             _decoder = new MpegFrameDecoder();
+
+            _encoderDelay = _reader.EncoderDelay;
+            _encoderPadding = _reader.EncoderPadding;
         }
 
         /// <summary>
@@ -70,7 +75,15 @@ namespace NLayer
         /// <summary>
         /// Data length of decoded data, in PCM.
         /// </summary>
-        public long Length { get { return _reader.SampleCount * _reader.Channels * sizeof(float); } }
+        public long Length
+        {
+            get
+            {
+                var count = _reader.SampleCount;
+                if (count < 0) return -1;
+                return (count - _encoderDelay - _encoderPadding) * _reader.Channels * sizeof(float);
+            }
+        }
 
         /// <summary>
         /// Media duration of the Mpeg file.
@@ -81,8 +94,30 @@ namespace NLayer
             {
                 var len = _reader.SampleCount;
                 if (len == -1) return TimeSpan.Zero;
-                return TimeSpan.FromSeconds((double)len / _reader.SampleRate);
+                return TimeSpan.FromSeconds((double)(len - _encoderDelay - _encoderPadding) / _reader.SampleRate);
             }
+        }
+
+        /// <summary>
+        /// Number of samples of encoder delay at the start of the stream (from LAME header).
+        /// These samples are automatically skipped during decoding.
+        /// Can be set manually for files without a LAME header.
+        /// </summary>
+        public int EncoderDelay
+        {
+            get { return _encoderDelay; }
+            set { _encoderDelay = value; }
+        }
+
+        /// <summary>
+        /// Number of padding samples at the end of the stream (from LAME header).
+        /// These samples are automatically trimmed during decoding.
+        /// Can be set manually for files without a LAME header.
+        /// </summary>
+        public int EncoderPadding
+        {
+            get { return _encoderPadding; }
+            set { _encoderPadding = value; }
         }
 
         /// <summary>
@@ -124,6 +159,7 @@ namespace NLayer
 
                     _position = newPos * sizeof(float) * _reader.Channels;
                     _eofFound = false;
+                    _decoderDelaySkipped = (newPos > 0 || _encoderDelay == 0);
 
                     // clear the decoder & buffer
                     _readBufOfs = _readBufLen = 0;
@@ -225,16 +261,32 @@ namespace NLayer
         {
             var cnt = 0;
 
+            // Total logical bytes of real audio (excludes encoder delay and end padding)
+            var rawSampleCount = _reader.SampleCount;
+            var totalBytes = rawSampleCount >= 0 ? (rawSampleCount - _encoderDelay - _encoderPadding) * _reader.Channels * sizeof(float) : long.MaxValue;
+
             // lock around the entire read operation so seeking doesn't bork our buffers as we decode
             lock (_seekLock)
             {
                 while (count > 0)
                 {
+                    // Trim end padding: stop once we've delivered all real audio
+                    if (_position >= totalBytes)
+                    {
+                        _eofFound = true;
+                        break;
+                    }
+
                     if (_readBufLen > _readBufOfs)
                     {
                         // we have bytes in the buffer, so copy them first
                         var temp = _readBufLen - _readBufOfs;
                         if (temp > count) temp = count;
+
+                        // Don't deliver past the logical end
+                        var remaining = (int)(totalBytes - _position);
+                        if (temp > remaining) temp = remaining;
+
                         if (bitDepth == 32)
                         {
                             Buffer.BlockCopy(_readBuf, _readBufOfs, buffer, index, temp);
@@ -300,6 +352,22 @@ namespace NLayer
                         {
                             _readBufLen = _decoder.DecodeFrame(frame, _readBuf, 0) * sizeof(float);
                             _readBufOfs = 0;
+
+                            // Skip encoder delay samples at the start of the stream
+                            if (!_decoderDelaySkipped)
+                            {
+                                var skipBytes = _encoderDelay * _reader.Channels * sizeof(float);
+                                if (skipBytes > 0 && skipBytes <= _readBufLen)
+                                {
+                                    _readBufOfs = skipBytes;
+                                }
+                                _decoderDelaySkipped = true;
+                                // If delay exhausted the entire buffer, mark it empty so we refill next iteration
+                                if (_readBufOfs >= _readBufLen)
+                                {
+                                    _readBufLen = _readBufOfs = 0;
+                                }
+                            }
                         }
                         catch (System.IO.InvalidDataException)
                         {


### PR DESCRIPTION
## Motivation

Fixes #9. When decoding MP3 files, NLayer returns more samples than the actual audio content because it ignores encoder delay (silence prepended by the encoder) and end-padding (silence appended to fill the last frame). This causes audible glitches when looping audio and incorrect reported durations/lengths.

## Approach

### Phase 1 — LAME header parsing + manual override

LAME-encoded files embed exact delay and padding values in the Xing/Info VBR header frame. The code for parsing this already existed in the codebase but was commented out. This PR re-enables it and wires the values end-to-end:

- **`VBRInfo`** — added `EncoderDelay` and `EncoderPadding` int properties
- **`MpegFrame.ParseXing()`** — reads 24 bytes at the LAME tag offset, validates the "LAME" signature + revision nibble, and extracts the 12-bit delay and 12-bit padding values from bytes 21–23
- **`MpegStreamReader`** — exposes `EncoderDelay`/`EncoderPadding` properties sourced from the VBR info (falling back to the ID3 tag, see Phase 2)
- **`MpegFile`** — applies the values during decoding: skips the leading delay samples on first read, trims trailing padding from the last frame, and adjusts the reported `Length`/`Duration`. Public settable `EncoderDelay`/`EncoderPadding` properties allow manual override when no metadata is present

Also fixed an infinite-loop edge case when the encoder delay exactly fills one frame — the buffer-empty condition wasn't firing because `_readBufLen` wasn't being zeroed.

### Phase 2 — iTunSMPB ID3v2 tag parsing

iTunes/AAC-derived workflows embed the same gapless information in a `TXXX` ID3v2 frame with description `"iTunSMPB"`. When no LAME tag is present, NLayer now falls back to this:

- **`ID3Frame.ParseV2()`** — walks ID3v2.3/2.4 child frames, finds `TXXX "iTunSMPB"`, decodes Latin-1/UTF-8/UTF-16 (including double-BOM after the null separator), and parses the hex delay and padding fields
- **`MpegStreamReader` constructor** — calls `ParseEagerIfNeeded()` on the ID3 frame immediately after it is found, before `ReadBuffer` advances into audio data. This avoids a pre-existing backward-seek bug in `ReadBuffer` that would crash on lazy parsing

## Validation

Tested against three files:

| Scenario | Source | Delay | Padding | Result |
|---|---|---|---|---|
| LAME-encoded file | LAME tag bytes 21–23 | 576 | 1080 | ✓ correct trim |
| iTunSMPB-tagged file | TXXX ID3v2 frame | 1152 | 1563 | 1,181,541 samples ✓ |
| Plain CBR, no metadata | — | 0 | 0 | 1,184,256 raw samples ✓ |

The iTunSMPB test file was the original file from issue #9 (`title.mp3`, created by Adobe Audition) with a `TXXX:iTunSMPB` frame injected containing the correct delay/padding values.