### PR TITLE
Enable .NET code-analysis (CA) analyzers and clean up findings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*.cs]
+# --- Analyzer rule overrides (see Directory.Build.props for AnalysisLevel) ---
+
+# Throw-helper rules. The helpers they suggest
+#   CA1510 -> ArgumentNullException.ThrowIfNull
+#   CA1511 -> ArgumentException.ThrowIfNullOrEmpty
+#   CA1512 -> ArgumentOutOfRangeException.ThrowIf*
+#   CA1513 -> ObjectDisposedException.ThrowIf
+# were added in .NET 6+ and do NOT exist in netstandard2.0, which NLayer still
+# targets. Applying the fixes would break the netstandard2.0 build, so these are
+# disabled until netstandard2.0 is dropped.
+dotnet_diagnostic.CA1510.severity = none
+dotnet_diagnostic.CA1511.severity = none
+dotnet_diagnostic.CA1512.severity = none
+dotnet_diagnostic.CA1513.severity = none

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,9 +19,13 @@
     <PackageIcon>naudio-icon.png</PackageIcon>
 
     <LangVersion>latest</LangVersion>
-    <!-- 0 compiler warnings today, so this is free; keeps the build clean.
-         (.NET code-analysis CA rules are not enabled here — see README.) -->
+    <!-- Treat warnings (compiler + analyzer) as errors to keep the build clean. -->
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- .NET code-analysis (CA) rules at the 8.0 'recommended' wave. Pinned to
+         8.0 (rather than 'latest') so a newer SDK can't silently introduce new
+         rules that break the build. Per-rule overrides live in .editorconfig. -->
+    <AnalysisLevel>8.0-recommended</AnalysisLevel>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 
     <!-- Strong naming. The .snk lives at the repo root, anchored via
          $(MSBuildThisFileDirectory) so csprojs at any depth resolve it.

--- a/NLayer.NAudioSupport/Mp3FrameDecompressor.cs
+++ b/NLayer.NAudioSupport/Mp3FrameDecompressor.cs
@@ -40,7 +40,8 @@
 
         public void Dispose()
         {
-            // no-op, since we don't have anything to do here...
+            // nothing to free, but satisfy the Dispose pattern for derived types
+            System.GC.SuppressFinalize(this);
         }
     }
 }

--- a/NLayer.NAudioSupport/Mp3FrameWrapper.cs
+++ b/NLayer.NAudioSupport/Mp3FrameWrapper.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace NLayer.NAudioSupport
 {
-    class Mp3FrameWrapper : IMpegFrame
+    sealed class Mp3FrameWrapper : IMpegFrame
     {
         Mp3Frame _frame;
 
@@ -129,7 +129,7 @@ namespace NLayer.NAudioSupport
 
         public int ReadBits(int bitCount)
         {
-            if (bitCount < 1 || bitCount > 32) throw new ArgumentOutOfRangeException("bitCount");
+            if (bitCount < 1 || bitCount > 32) throw new ArgumentOutOfRangeException(nameof(bitCount));
             while (_bitsRead < bitCount)
             {
                 if (_readOffset == _frame.FrameLength) throw new System.IO.EndOfStreamException();

--- a/NLayer.Tests/NLayer.Tests.csproj
+++ b/NLayer.Tests/NLayer.Tests.csproj
@@ -5,6 +5,8 @@
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>
+    <!-- Underscores in test method names are idiomatic (Given_When_Then). -->
+    <NoWarn>$(NoWarn);CA1707</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NLayer/Decoder/BitReservoir.cs
+++ b/NLayer/Decoder/BitReservoir.cs
@@ -2,14 +2,14 @@
 
 namespace NLayer.Decoder
 {
-    class BitReservoir
+    sealed class BitReservoir
     {
         // Per the spec, the maximum buffer size for layer III is 7680 bits, which is 960 bytes.
         // The only catch is if we're decoding a "free" frame, which could be a lot more (since
         //  some encoders allow higher bitrates to maintain audio transparency).
         byte[] _buf = new byte[8192];
-        int _start = 0, _end = -1, _bitsLeft = 0;
-        long _bitsRead = 0L;
+        int _start, _end = -1, _bitsLeft;
+        long _bitsRead;
 
         static int GetSlots(IMpegFrame frame)
         {
@@ -90,7 +90,7 @@ namespace NLayer.Decoder
 
         public int TryPeekBits(int count, out int readCount)
         {
-            if (count < 0 || count > 32) throw new ArgumentOutOfRangeException("count", "Must return between 0 and 32 bits!");
+            if (count < 0 || count > 32) throw new ArgumentOutOfRangeException(nameof(count), "Must return between 0 and 32 bits!");
 
             // if we don't have any bits left, just return no bits read
             if (_bitsLeft == 0 || count == 0)
@@ -165,7 +165,7 @@ namespace NLayer.Decoder
             if (count > 0)
             {
                 // make sure we have enough bits to skip
-                if (count > BitsAvailable) throw new ArgumentOutOfRangeException("count");
+                if (count > BitsAvailable) throw new ArgumentOutOfRangeException(nameof(count));
 
                 // now calculate the new positions
                 var offset = (8 - _bitsLeft) + count;

--- a/NLayer/Decoder/FrameBase.cs
+++ b/NLayer/Decoder/FrameBase.cs
@@ -4,7 +4,7 @@ namespace NLayer.Decoder
 {
     abstract class FrameBase
     {
-        static int _totalAllocation = 0;
+        static int _totalAllocation;
         static internal int TotalAllocation
         {
             get { return System.Threading.Interlocked.CompareExchange(ref _totalAllocation, 0, 0); }
@@ -60,7 +60,7 @@ namespace NLayer.Decoder
         {
             if (_savedBuffer != null)
             {
-                if (offset < 0) throw new ArgumentOutOfRangeException();
+                if (offset < 0) throw new ArgumentOutOfRangeException(nameof(offset));
                 if (offset >= _savedBuffer.Length) return -1;
 
                 return (int)_savedBuffer[offset];

--- a/NLayer/Decoder/Huffman.cs
+++ b/NLayer/Decoder/Huffman.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace NLayer.Decoder
 {
-    class Huffman
+    sealed class Huffman
     {
         #region Hardcoded Tables (from the spec)
 
@@ -1052,7 +1052,7 @@ namespace NLayer.Decoder
             return list[0];
         }
 
-        class HuffmanListNode
+        sealed class HuffmanListNode
         {
             internal byte Value;
 

--- a/NLayer/Decoder/ID3Frame.cs
+++ b/NLayer/Decoder/ID3Frame.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace NLayer.Decoder
 {
-    class ID3Frame : FrameBase
+    sealed class ID3Frame : FrameBase
     {
         internal static ID3Frame TrySync(uint syncMark)
         {
@@ -91,18 +91,18 @@ namespace NLayer.Decoder
             switch (_version)
             {
                 case 2:
-                    ParseV2();
+                    ID3Frame.ParseV2();
                     break;
                 case 1:
-                    ParseV1Enh();
+                    ID3Frame.ParseV1Enh();
                     break;
                 case 0:
-                    ParseV1(3);
+                    ID3Frame.ParseV1(3);
                     break;
             }
         }
 
-        void ParseV1(int offset)
+        static void ParseV1(int offset)
         {
             //var buffer = new byte[125];
             //if (Read(offset, buffer) == 125)
@@ -138,9 +138,9 @@ namespace NLayer.Decoder
             //}
         }
 
-        void ParseV1Enh()
+        static void ParseV1Enh()
         {
-            ParseV1(230);
+            ID3Frame.ParseV1(230);
 
             //var buffer = new byte[223];
             //if (Read(4, buffer) == 223)
@@ -171,7 +171,7 @@ namespace NLayer.Decoder
             //}
         }
 
-        void ParseV2()
+        static void ParseV2()
         {
             // v2 is much more complicated than v1...  don't worry about it for now
             // look for any merged frames, as well
@@ -197,7 +197,7 @@ namespace NLayer.Decoder
         //public TimeSpan StartTime { get; private set; }
         //public TimeSpan EndTime { get; private set; }
 
-        internal void Merge(ID3Frame newFrame)
+        internal static void Merge(ID3Frame newFrame)
         {
             // just save off the frame for parsing later
         }

--- a/NLayer/Decoder/ID3Frame.cs
+++ b/NLayer/Decoder/ID3Frame.cs
@@ -197,9 +197,14 @@ namespace NLayer.Decoder
         //public TimeSpan StartTime { get; private set; }
         //public TimeSpan EndTime { get; private set; }
 
-        internal static void Merge(ID3Frame newFrame)
+        // TODO: ID3 2.4 allows later tags to override earlier ones. This is an
+        // unimplemented stub; when implemented it will merge newFrame's fields
+        // into this instance, so it is intentionally kept as an instance method.
+#pragma warning disable CA1822 // Mark members as static
+        internal void Merge(ID3Frame newFrame)
         {
             // just save off the frame for parsing later
         }
+#pragma warning restore CA1822
     }
 }

--- a/NLayer/Decoder/LayerDecoderBase.cs
+++ b/NLayer/Decoder/LayerDecoderBase.cs
@@ -232,9 +232,9 @@ namespace NLayer.Decoder
 
             DCT32(data, synBuf, k);
 
-            BuildUVec(ippuv, synBuf, k);
+            LayerDecoderBase.BuildUVec(ippuv, synBuf, k);
 
-            DewindowOutput(ippuv, data);
+            LayerDecoderBase.DewindowOutput(ippuv, data);
         }
 
         void GetBufAndOffset(int channel, out float[] synBuf, out int k)
@@ -377,7 +377,7 @@ namespace NLayer.Decoder
             _out[7] = oo8[3];
         }
 
-        void BuildUVec(float[] u_vec, float[] cur_synbuf, int k)
+        static void BuildUVec(float[] u_vec, float[] cur_synbuf, int k)
         {
             int i, j, uvp = 0;
 
@@ -407,7 +407,7 @@ namespace NLayer.Decoder
             }
         }
 
-        void DewindowOutput(float[] u_vec, float[] samples)
+        static void DewindowOutput(float[] u_vec, float[] samples)
         {
             for (int i = 0; i < 512; i++)
             {

--- a/NLayer/Decoder/LayerIDecoder.cs
+++ b/NLayer/Decoder/LayerIDecoder.cs
@@ -9,7 +9,7 @@ namespace NLayer.Decoder
 {
     // Layer I is really just a special case of Layer II...  1 granule, 4 allocation bits per subband, 1 scalefactor per active subband, no grouping
     // That (of course) means we literally have no logic here
-    class LayerIDecoder : LayerIIDecoderBase
+    sealed class LayerIDecoder : LayerIIDecoderBase
     {
         static internal bool GetCRC(MpegFrame frame, ref uint crc)
         {

--- a/NLayer/Decoder/LayerIIDecoder.cs
+++ b/NLayer/Decoder/LayerIIDecoder.cs
@@ -8,7 +8,7 @@ using System;
 namespace NLayer.Decoder
 {
     // there's not much we have to do here... table selection, granule count, scalefactor selection
-    class LayerIIDecoder : LayerIIDecoderBase
+    sealed class LayerIIDecoder : LayerIIDecoderBase
     {
         static internal bool GetCRC(MpegFrame frame, ref uint crc)
         {

--- a/NLayer/Decoder/LayerIIIDecoder.cs
+++ b/NLayer/Decoder/LayerIIIDecoder.cs
@@ -45,7 +45,7 @@ namespace NLayer.Decoder
         #region Child Classes
 
         // This class is based on the Fluendo hybrid logic.
-        class HybridMDCT
+        sealed class HybridMDCT
         {
             const float PI = (float)Math.PI;
 
@@ -580,7 +580,7 @@ namespace NLayer.Decoder
                         {
                             // reorder & antialias mixed blocks
                             Reorder(buf, true);
-                            AntiAlias(buf, true);
+                            LayerIIIDecoder.AntiAlias(buf, true);
                         }
                         else
                         {
@@ -591,14 +591,14 @@ namespace NLayer.Decoder
                     else
                     {
                         // antialias long blocks
-                        AntiAlias(buf, false);
+                        LayerIIIDecoder.AntiAlias(buf, false);
                     }
 
                     // hybrid processing
                     _hybrid.Apply(buf, ch, blockType, blockSplit && mixedBlock);
 
                     // frequency inversion
-                    FrequencyInversion(buf);
+                    LayerIIIDecoder.FrequencyInversion(buf);
 
                     // inverse polyphase
                     InversePolyphase(buf, ch, offset, chanBufs[ch]);
@@ -1881,7 +1881,7 @@ namespace NLayer.Decoder
 
         #endregion
 
-        void AntiAlias(float[] buf, bool mixedBlock)
+        static void AntiAlias(float[] buf, bool mixedBlock)
         {
             int sblim;
             if (mixedBlock)
@@ -1909,7 +1909,7 @@ namespace NLayer.Decoder
 
         #region Frequency Inversion
 
-        void FrequencyInversion(float[] buf)
+        static void FrequencyInversion(float[] buf)
         {
             for (int ss = 1; ss < SSLIMIT; ss += 2)
             {

--- a/NLayer/Decoder/MpegFrame.cs
+++ b/NLayer/Decoder/MpegFrame.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace NLayer.Decoder
 {
-    class MpegFrame : FrameBase, IMpegFrame
+    sealed class MpegFrame : FrameBase, IMpegFrame
     {
         static readonly int[][][] _bitRateTable =
         {
@@ -64,7 +64,7 @@ namespace NLayer.Decoder
         // 8
         int _readOffset, _bitsRead;
         // 8
-        ulong _bitBucket = 0UL;
+        ulong _bitBucket;
         // 8
         long _offset;
         // 4
@@ -524,7 +524,7 @@ namespace NLayer.Decoder
 
         public int ReadBits(int bitCount)
         {
-            if (bitCount < 1 || bitCount > 32) throw new ArgumentOutOfRangeException("bitCount");
+            if (bitCount < 1 || bitCount > 32) throw new ArgumentOutOfRangeException(nameof(bitCount));
             if (_isMuted) return 0;
 
             while (_bitsRead < bitCount)

--- a/NLayer/Decoder/MpegStreamReader.cs
+++ b/NLayer/Decoder/MpegStreamReader.cs
@@ -174,7 +174,7 @@ namespace NLayer.Decoder
                                         else
                                         {
                                             // grrr...  the ID3 2.4 spec says tags can be anywhere in the file and that later tags can override earlier ones...  boo
-                                            ID3Frame.Merge(f);
+                                            _id3Frame.Merge(f);
                                         }
 
                                         _readOffset += f.Length;

--- a/NLayer/Decoder/MpegStreamReader.cs
+++ b/NLayer/Decoder/MpegStreamReader.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace NLayer.Decoder
 {
-    class MpegStreamReader
+    sealed class MpegStreamReader
     {
         ID3Frame _id3Frame, _id3v1Frame;
         RiffHeaderFrame _riffHeaderFrame;
@@ -174,7 +174,7 @@ namespace NLayer.Decoder
                                         else
                                         {
                                             // grrr...  the ID3 2.4 spec says tags can be anywhere in the file and that later tags can override earlier ones...  boo
-                                            _id3Frame.Merge(f);
+                                            ID3Frame.Merge(f);
                                         }
 
                                         _readOffset += f.Length;
@@ -207,8 +207,14 @@ namespace NLayer.Decoder
 
                         if (!_canSeek)
                         {
-                            // gotta finish filling the buffer!!
+                            // Intentional guard: free-format frames are not supported on
+                            // forward-only streams. This sits in a finally only because the
+                            // free-frame length is finalised here on every exit path; the
+                            // normal paths above do not throw, so it does not mask another
+                            // in-flight exception.
+#pragma warning disable CA2219 // Do not raise exceptions in finally clauses
                             throw new InvalidOperationException("Free frames cannot be read properly from forward-only streams!");
+#pragma warning restore CA2219
                         }
 
                         // if _lastFree hasn't changed (we got a non-MPEG frame), clear it out
@@ -221,7 +227,7 @@ namespace NLayer.Decoder
             }
         }
 
-        class ReadBuffer
+        sealed class ReadBuffer
         {
             public byte[] Data;
             public long BaseOffset;
@@ -530,17 +536,17 @@ namespace NLayer.Decoder
         internal int Read(long offset, byte[] buffer, int index, int count)
         {
             // make sure the offset is at least positive
-            if (offset < 0L) throw new ArgumentOutOfRangeException("offset");
+            if (offset < 0L) throw new ArgumentOutOfRangeException(nameof(offset));
 
             // make sure the buffer is valid
-            if (index < 0 || index + count > buffer.Length) throw new ArgumentOutOfRangeException("index");
+            if (index < 0 || index + count > buffer.Length) throw new ArgumentOutOfRangeException(nameof(index));
 
             return _readBuf.Read(this, offset, buffer, index, count);
         }
 
         internal int ReadByte(long offset)
         {
-            if (offset < 0L) throw new ArgumentOutOfRangeException("offset");
+            if (offset < 0L) throw new ArgumentOutOfRangeException(nameof(offset));
 
             return _readBuf.ReadByte(this, offset);
         }

--- a/NLayer/Decoder/RiffHeaderFrame.cs
+++ b/NLayer/Decoder/RiffHeaderFrame.cs
@@ -8,7 +8,7 @@ namespace NLayer.Decoder
     /// <summary>
     /// RIFF header reader
     /// </summary>
-    class RiffHeaderFrame : FrameBase
+    sealed class RiffHeaderFrame : FrameBase
     {
         internal static RiffHeaderFrame TrySync(uint syncMark)
         {

--- a/NLayer/Decoder/VBRInfo.cs
+++ b/NLayer/Decoder/VBRInfo.cs
@@ -1,6 +1,6 @@
 ﻿namespace NLayer.Decoder
 {
-    class VBRInfo
+    sealed class VBRInfo
     {
         internal VBRInfo() { }
 

--- a/NLayer/MpegFile.cs
+++ b/NLayer/MpegFile.cs
@@ -51,6 +51,7 @@ namespace NLayer
                 _stream.Dispose();
                 _closeStream = false;
             }
+            GC.SuppressFinalize(this);
         }
         /// <summary>
         /// Sample rate of source Mpeg, in Hertz.
@@ -94,7 +95,7 @@ namespace NLayer
             set
             {
                 if (!_reader.CanSeek) throw new InvalidOperationException("Cannot Seek!");
-                if (value < 0L) throw new ArgumentOutOfRangeException("value");
+                if (value < 0L) throw new ArgumentOutOfRangeException(nameof(value));
 
                 // we're thinking in 4-byte samples, pcmStep interleaved...  adjust accordingly
                 var samples = value / sizeof(float) / _reader.Channels;
@@ -111,7 +112,7 @@ namespace NLayer
                 {
                     // seek the stream
                     var newPos = _reader.SeekTo(samples);
-                    if (newPos == -1) throw new ArgumentOutOfRangeException("value");
+                    if (newPos == -1) throw new ArgumentOutOfRangeException(nameof(value));
 
                     _decoder.Reset();
 
@@ -168,7 +169,7 @@ namespace NLayer
         /// <returns>Sample size actually reads, in bytes.</returns>
         public int ReadSamples(byte[] buffer, int index, int count)
         {
-            if (index < 0 || index + count > buffer.Length) throw new ArgumentOutOfRangeException("index");
+            if (index < 0 || index + count > buffer.Length) throw new ArgumentOutOfRangeException(nameof(index));
 
             // make sure we're asking for an even number of samples
             count -= (count % sizeof(float));
@@ -198,7 +199,7 @@ namespace NLayer
         /// <returns>Sample count actually reads.</returns>
         public int ReadSamples(float[] buffer, int index, int count)
         {
-            if (index < 0 || index + count > buffer.Length) throw new ArgumentOutOfRangeException("index");
+            if (index < 0 || index + count > buffer.Length) throw new ArgumentOutOfRangeException(nameof(index));
 
             // ReadSampleImpl "thinks" in bytes, so adjust accordingly
             return ReadSamplesImpl(buffer, index * sizeof(float), count * sizeof(float), 32) / sizeof(float);
@@ -206,14 +207,14 @@ namespace NLayer
 
         public int ReadSamplesInt16(byte[] buffer, int index, int count)
         {
-            if (index < 0 || index + count > buffer.Length * sizeof(short)) throw new ArgumentOutOfRangeException("index");
+            if (index < 0 || index + count > buffer.Length * sizeof(short)) throw new ArgumentOutOfRangeException(nameof(index));
 
             return ReadSamplesImpl(buffer, index, count, 16) * sizeof(short) / sizeof(float);
         }
 
         public int ReadSamplesInt8(byte[] buffer, int index, int count)
         {
-            if (index < 0 || index + count > buffer.Length * sizeof(float)) throw new ArgumentOutOfRangeException("index");
+            if (index < 0 || index + count > buffer.Length * sizeof(float)) throw new ArgumentOutOfRangeException(nameof(index));
 
             return ReadSamplesImpl(buffer, index, count, 8) * sizeof(byte) / sizeof(float);
         }

--- a/NLayer/MpegFrameDecoder.cs
+++ b/NLayer/MpegFrameDecoder.cs
@@ -59,14 +59,14 @@ namespace NLayer
         /// <returns></returns>
         public int DecodeFrame(IMpegFrame frame, byte[] dest, int destOffset)
         {
-            if (frame == null) throw new ArgumentNullException("frame");
-            if (dest == null) throw new ArgumentNullException("dest");
-            if (destOffset % 4 != 0) throw new ArgumentException("Must be an even multiple of 4", "destOffset");
+            if (frame == null) throw new ArgumentNullException(nameof(frame));
+            if (dest == null) throw new ArgumentNullException(nameof(dest));
+            if (destOffset % 4 != 0) throw new ArgumentException("Must be an even multiple of 4", nameof(destOffset));
 
             var bufferAvailable = (dest.Length - destOffset) / 4;
             if (bufferAvailable < (frame.ChannelMode == MpegChannelMode.Mono ? 1 : 2) * frame.SampleCount)
             {
-                throw new ArgumentException("Buffer not large enough!  Must be big enough to hold the frame's entire output.  This is up to 9,216 bytes.", "dest");
+                throw new ArgumentException("Buffer not large enough!  Must be big enough to hold the frame's entire output.  This is up to 9,216 bytes.", nameof(dest));
             }
 
             return DecodeFrameImpl(frame, dest, destOffset / 4) * 4;
@@ -94,12 +94,12 @@ namespace NLayer
         /// <returns></returns>
         public int DecodeFrame(IMpegFrame frame, float[] dest, int destOffset)
         {
-            if (frame == null) throw new ArgumentNullException("frame");
-            if (dest == null) throw new ArgumentNullException("dest");
+            if (frame == null) throw new ArgumentNullException(nameof(frame));
+            if (dest == null) throw new ArgumentNullException(nameof(dest));
 
             if (dest.Length - destOffset < (frame.ChannelMode == MpegChannelMode.Mono ? 1 : 2) * frame.SampleCount)
             {
-                throw new ArgumentException("Buffer not large enough!  Must be big enough to hold the frame's entire output.  This is up to 2,304 elements.", "dest");
+                throw new ArgumentException("Buffer not large enough!  Must be big enough to hold the frame's entire output.  This is up to 2,304 elements.", nameof(dest));
             }
 
             return DecodeFrameImpl(frame, dest, destOffset);

--- a/README.md
+++ b/README.md
@@ -66,9 +66,11 @@ Every push and pull request is built and tested by the `build` GitHub Actions
 workflow.
 
 Assemblies are strong-named with `NLayerStrongNameKey.snk` (checked into the
-repo root). Compiler warnings are treated as errors; the broader .NET
-code-analysis (CA) analyzers are not enabled — turning them on surfaces ~110
-mostly-mechanical style/perf suggestions that can be addressed incrementally.
+repo root). Warnings — both compiler and .NET code-analysis (CA) analyzers — are
+treated as errors. The analyzer baseline is `8.0-recommended` (set in
+`Directory.Build.props`); per-rule overrides live in `.editorconfig`. Notably the
+throw-helper rules (CA1510–CA1513) are disabled because their helpers don't exist
+in `netstandard2.0`, which NLayer still targets.
 
 ## Releasing
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,3 +28,7 @@ section matching the version being shipped:
 - Added an initial `NLayer.Tests` project.
 - `NLayer.NAudioSupport` continues to target NAudio 2; NAudio 3 support
   will follow once the NAudio 3 API stabilises.
+- Enabled .NET code-analysis (CA) analyzers at the `8.0-recommended` baseline
+  with warnings as errors, and cleaned up the resulting findings (sealed
+  internal types, `nameof`, redundant initializers removed, `static` helpers,
+  `GC.SuppressFinalize` in `Dispose`).


### PR DESCRIPTION
Turns on the .NET code-analysis (CA) analyzers for full NAudio-style quality gating and cleans up the resulting findings.

> **Stacked on #48.** Base is the modernization branch so this diff shows only the analyzer work. Once #48 merges, GitHub will retarget this to `master`.

## Configuration
- `Directory.Build.props`: `AnalysisLevel=8.0-recommended` + `EnforceCodeStyleInBuild`. Pinned to the **8.0** wave (not `latest`) so a newer SDK can't silently introduce new rules that break the build. Warnings (compiler + analyzer) are errors.
- `.editorconfig`: disables the throw-helper rules **CA1510–CA1513** (`ArgumentNullException.ThrowIfNull`, `ArgumentOutOfRangeException.ThrowIf*`, etc.) — those helpers don't exist in `netstandard2.0`, which NLayer still targets, so applying the fixes would break that target.

## Fixes applied
| Rule | Fix | Notes |
| --- | --- | --- |
| CA1852 | Sealed 12 internal types | leaf decoder/frame types; minor perf win |
| CA1507 / CA2208 | `nameof(...)` in argument exceptions | |
| CA1805 | Removed redundant `= 0` / `= 0L` / `= 0UL` initializers | |
| CA1822 | Marked side-effect-free helpers `static` | behaviour-preserving (no instance-state access) |
| CA1816 | `GC.SuppressFinalize(this)` in `Dispose()` | `MpegFile`, `Mp3FrameDecompressor` |

## Judgment calls
- **CA2219** (throw in `finally`, `MpegStreamReader`) — suppressed at the one site with a justification comment. It's an intentional "not supported" guard for free-format frames on forward-only streams; the surrounding normal paths don't throw, so it can't mask an in-flight exception. Refactoring that resync control flow wasn't worth the risk in untested code.
- **CA1707** (underscores in names) — the `NLayer.Tests` project opts out via `NoWarn`, since `Given_When_Then` test names are idiomatic. Production code is unaffected.

## Verification
All three projects build clean with warnings-as-errors for both `netstandard2.0` and `net8.0`; all 5 tests pass. The auto-fixes are mechanical and behaviour-preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N6vU6LqLtMY4eFXHN72yxx

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6vU6LqLtMY4eFXHN72yxx)_