### PR TITLE
Update branch references from master to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,10 @@
 name: build
 
-# Build & test on every PR, every push to master, and on demand.
+# Build & test on every PR, every push to main, and on demand.
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,14 +34,14 @@ jobs:
         with:
           dotnet-version: 8.0.x
 
-      # Dispatch must come from master. Tag pushes are unrestricted because
+      # Dispatch must come from main. Tag pushes are unrestricted because
       # the tag itself is the gate.
       - name: Verify branch (dispatch only)
         if: github.event_name == 'workflow_dispatch'
         shell: pwsh
         run: |
-          if ($env:GITHUB_REF -ne 'refs/heads/master') {
-            Write-Error "Release dispatch must be from master (got $env:GITHUB_REF)."
+          if ($env:GITHUB_REF -ne 'refs/heads/main') {
+            Write-Error "Release dispatch must be from main (got $env:GITHUB_REF)."
             exit 1
           }
 

--- a/Docs/Releasing.md
+++ b/Docs/Releasing.md
@@ -38,7 +38,7 @@ Use this to put a preview on NuGet for testing before committing to a final
 version.
 
 1. Go to **Actions → release → Run workflow**.
-2. Select the **`master`** branch (the workflow refuses to dispatch from any
+2. Select the **`main`** branch (the workflow refuses to dispatch from any
    other branch).
 3. Optionally fill in **`milestone`**:
    - **Leave blank** → ships `…-preview.<run_number>` (auto-incrementing), e.g.
@@ -55,13 +55,13 @@ You can trigger the same `workflow_dispatch` with the
 
 ```sh
 # Auto preview.<run_number>, e.g. 2.0.0-preview.42
-gh workflow run release.yml --ref master
+gh workflow run release.yml --ref main
 
 # Named milestone, e.g. 2.0.0-rc.1
-gh workflow run release.yml --ref master -f milestone=rc.1
+gh workflow run release.yml --ref main -f milestone=rc.1
 ```
 
-`--ref master` is required — the workflow refuses to dispatch from any other
+`--ref main` is required — the workflow refuses to dispatch from any other
 branch. To watch the run you just started:
 
 ```sh
@@ -89,7 +89,7 @@ No `git` tag and no GitHub Release are created for pre-releases.
 
    The workflow **fails fast** if a final release has no matching
    `### <version> (…)` section, so don't skip this.
-3. **Commit** both changes to `master` (via PR).
+3. **Commit** both changes to `main` (via PR).
 4. **Tag and push:**
 
    ```sh
@@ -141,7 +141,7 @@ steps succeed before tagging your first final release.
 
 | Symptom | Cause / fix |
 | --- | --- |
-| `Release dispatch must be from master` | You ran the workflow from another branch. Re-run it from `master`. |
+| `Release dispatch must be from main` | You ran the workflow from another branch. Re-run it from `main`. |
 | `Tag vX.Y.Z does not match VersionPrefix …` | The tag and `<VersionPrefix>` differ. Bump the prefix (or fix the tag), commit, delete the bad tag, and retag. |
 | `RELEASE_NOTES.md has no '### X.Y.Z (...)' section` | Rename `### Unreleased` to `### X.Y.Z (DD MMM YYYY)` before tagging. |
 | NuGet login/push fails with an auth error | Trusted publishing isn't configured, or `NUGET_USER` is missing/wrong. See [one-time setup](#one-time-setup-trusted-publishing). |

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ workflow, which uses NuGet trusted publishing (OIDC) — no API key is stored in
 the repository.
 
 - **Pre-release:** run the `release` workflow manually (Actions → release →
-  Run workflow) from `master`. It publishes `<VersionPrefix>-preview.<run>`,
+  Run workflow) from `main`. It publishes `<VersionPrefix>-preview.<run>`,
   or pass a `milestone` such as `rc.1` for `<VersionPrefix>-rc.1`.
 - **Final release:** bump `<VersionPrefix>`, rename the `### Unreleased`
   heading in `RELEASE_NOTES.md` to `### <version> (DD MMM YYYY)`, commit, then


### PR DESCRIPTION
Prepares the repo for renaming the default branch from `master` to `main`. The GitHub-side rename (Settings → Branches) doesn't edit file contents, so this PR updates every in-repo reference:

**Pipelines**
- `build.yml`: push trigger → `branches: [main]` (PR validation is unaffected — the `pull_request:` trigger has no branch filter).
- `release.yml`: the `workflow_dispatch` branch guard now requires `refs/heads/main`, so releases can be dispatched from `main`.

**Docs**
- `README.md` and `Docs/Releasing.md`: release instructions and the `--ref` / troubleshooting references now use `main`.

No `master` references remain (`grep -rni master README.md Docs .github` is clean).

### Suggested rollout
1. Merge this PR (its checks run via the unfiltered `pull_request:` trigger, so they pass while the default branch is still `master`).
2. Rename `master` → `main` in **Settings → Branches**. GitHub makes `main` the default, retargets open PRs, and migrates branch-protection rules.
3. Contributors repoint local clones: `git branch -m master main && git fetch origin && git branch -u origin/main main && git remote set-head origin -a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PPjVnLPEykguDwA4VVTU4f)_