### PR TITLE
Release NLayer 2.0.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,10 @@ section matching the version being shipped:
 
 ### Unreleased
 
+<!-- Add notes for the next release here as PRs land. -->
+
+### 2.0.0 (28 Jun 2026)
+
 - Modernised build: dropped `netstandard1.3`; packages now target
   `netstandard2.0` and `net8.0`.
 - Unified `NLayer` and `NLayer.NAudioSupport` on a single version (2.0.0).


### PR DESCRIPTION
Prepares the NLayer **2.0.0** final release.

## What this does

- Promotes the curated `### Unreleased` notes in `RELEASE_NOTES.md` to a dated `### 2.0.0 (28 Jun 2026)` section. The release workflow requires this section to exist for a `vX.Y.Z` tag push and fails fast otherwise.
- Adds a fresh empty `### Unreleased` section for the next cycle.

No version bump is needed: `<VersionPrefix>` in `Directory.Build.props` is already `2.0.0`, which matches the `v2.0.0` tag.

## Release steps (from `Docs/Releasing.md`)

1. ✅ Curate notes + confirm `VersionPrefix` (this PR)
2. ⏭️ Merge this PR to `main`
3. ⏭️ Tag and push `v2.0.0` on the merge commit, which triggers the `release` workflow to build, test, pack, publish both `NLayer` and `NLayer.NAudioSupport` to NuGet (trusted publishing / OIDC), and create the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018xkT7zkY7nrGLLWAFGfd6P)_